### PR TITLE
Allow border visibility and colour to be customised

### DIFF
--- a/DeskFrame/Converters/BooleanToBorderThicknessConverter.cs
+++ b/DeskFrame/Converters/BooleanToBorderThicknessConverter.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace DeskFrame
+{
+    public class BooleanToBorderThicknessConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool enabled)
+            {
+                return enabled ? new Thickness(1) : new Thickness(0);
+            }
+            return new Thickness(0);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DeskFrame/Core/Instance.cs
+++ b/DeskFrame/Core/Instance.cs
@@ -18,6 +18,8 @@ public class Instance : INotifyPropertyChanged
     private bool _isLocked;
     private string _titleBarColor = "#000000";
     private string _titleTextColor = "#FFFFFF";
+    private string _borderColor = "#FFFFFF";
+    private bool _borderEnabled = false;
     private Forms.HorizontalAlignment _titleTextAlignment = Forms.HorizontalAlignment.Center;
     private string? _titleText;
 
@@ -162,6 +164,32 @@ public class Instance : INotifyPropertyChanged
         }
     }
 
+    public string BorderColor
+    {
+        get => _borderColor;
+        set
+        {
+            if (_borderColor != value)
+            {
+                _borderColor = value;
+                OnPropertyChanged(nameof(BorderColor), value);
+            }
+        }
+    }
+
+    public bool BorderEnabled
+    {
+        get => _borderEnabled;
+        set
+        {
+            if (_borderEnabled != value)
+            {
+                _borderEnabled = value;
+                OnPropertyChanged(nameof(BorderEnabled), value.ToString());
+            }
+        }
+    }
+
     public string? TitleText
     {
         get => _titleText;
@@ -201,6 +229,8 @@ public class Instance : INotifyPropertyChanged
         _isLocked = instance._isLocked;
         _titleBarColor = instance._titleBarColor;
         _titleTextColor = instance._titleTextColor;
+        _borderColor = instance._borderColor;
+        _borderEnabled = instance._borderEnabled;
         _titleTextAlignment = instance._titleTextAlignment;
     }
 
@@ -217,6 +247,8 @@ public class Instance : INotifyPropertyChanged
         _isLocked = false;
         _titleBarColor = "#000000";
         _titleTextColor = "#FFFFFF";
+        _borderColor = "#FFFFFF";
+        _borderEnabled = false;
         _titleTextAlignment = Forms.HorizontalAlignment.Center;
     }
 

--- a/DeskFrame/Core/InstanceController.cs
+++ b/DeskFrame/Core/InstanceController.cs
@@ -79,6 +79,8 @@ public class InstanceController
                 key.SetValue("TitleTextColor", instance.TitleTextColor!);
                 key.SetValue("TitleTextAlignment", instance.TitleTextAlignment.ToString());
                 key.SetValue("TitleText", instance.TitleText);
+                key.SetValue("BorderColor", instance.BorderColor!);
+                key.SetValue("BorderEnabled", instance.BorderEnabled!);
             }
         }
         catch { }
@@ -243,6 +245,14 @@ public class InstanceController
                                                 {
                                                     temp.TitleTextAlignment = alignment;
                                                 }
+                                                break;
+                                            case "BorderColor":
+                                                temp.BorderColor = value.ToString()!;
+                                                Debug.WriteLine($"BorderColor added\t{temp.BorderColor}");
+                                                break;
+                                            case "BorderEnabled":
+                                                temp.BorderEnabled = bool.Parse(value.ToString()!);
+                                                Debug.WriteLine($"BorderEnabled added\t{temp.BorderEnabled}");
                                                 break;
                                             default:
                                                 Debug.WriteLine($"Unknown value: {valueName}");

--- a/DeskFrame/DeskFrameWindow.xaml
+++ b/DeskFrame/DeskFrameWindow.xaml
@@ -34,6 +34,8 @@
             <DoubleAnimation Storyboard.TargetProperty="Height" Duration="0:0:0.2" />
         </Storyboard>
 
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <local:BooleanToBorderThicknessConverter x:Key="BooleanToBorderThicknessConverter"/>
 
         <!-- DataTemplate to display each file item -->
         <DataTemplate x:Key="FileItemTemplate">
@@ -69,7 +71,7 @@
     <WindowChrome.WindowChrome>
         <WindowChrome GlassFrameThickness="0,5,0,5"  CaptionHeight="0" ResizeBorderThickness="5" CornerRadius="5" />
     </WindowChrome.WindowChrome>
-    <Border  CornerRadius="5" x:Name="windowBorder" Background="#02000000">
+    <Border CornerRadius="5" x:Name="windowBorder" Background="#02000000" BorderThickness="{Binding Instance.BorderEnabled, Converter={StaticResource BooleanToBorderThicknessConverter}}" BorderBrush="{Binding Instance.BorderColor}">
 
         <Grid>
 

--- a/DeskFrame/FrameSettingsDialog.xaml
+++ b/DeskFrame/FrameSettingsDialog.xaml
@@ -11,7 +11,7 @@
         Background="#66232323" 
         WindowStyle="None" 
         ResizeMode="NoResize"
-        Height="450" 
+        Height="575" 
         Width="300"
         MaxWidth="300">
     <Grid>
@@ -26,6 +26,9 @@
                 <TextBox x:Name="TitleBarColorTextBox" Margin="0,0,0,20" TextChanged="TitleBarColorTextBox_TextChanged"/>
                 <Label Content="Title Text Color (hex):" Height="30"/>
                 <TextBox x:Name="TitleTextColorTextBox" Margin="0,0,0,20" TextChanged="TitleTextColorTextBox_TextChanged"/>
+                <CheckBox x:Name="BorderEnabledCheckBox" Content="Enable Border" Margin="0,0,0,10" Checked="BorderEnabledCheckBox_Checked" Unchecked="BorderEnabledCheckBox_Checked"/>
+                <Label Content="Border Color (hex):" Height="30"/>
+                <TextBox x:Name="BorderColorTextBox" Margin="0,0,0,20" TextChanged="BorderColorTextBox_TextChanged"/>
                 <Label Content="Title Text:" Height="30"/>
                 <TextBox x:Name="TitleTextBox" Margin="0,0,0,20" TextChanged="TitleTextBox_TextChanged"/>
                 <Label Content="Title Text Alignment:" Height="30"/>

--- a/DeskFrame/FrameSettingsDialog.xaml.cs
+++ b/DeskFrame/FrameSettingsDialog.xaml.cs
@@ -10,6 +10,7 @@ namespace DeskFrame
         private bool _isValidTitleTextColor = false;
         private bool _isValidTitleTextAlignment = true;
         private bool _isValidTitleText = true;
+        private bool _isValidBorderColor = false;
 
         public FrameSettingsDialog(Instance instance)
         {
@@ -17,8 +18,11 @@ namespace DeskFrame
             _instance = instance;
             TitleBarColorTextBox.Text = _instance.TitleBarColor;
             TitleTextColorTextBox.Text = _instance.TitleTextColor;
+            BorderColorTextBox.Text = _instance.BorderColor;
+            BorderEnabledCheckBox.IsChecked = _instance.BorderEnabled;
             TitleTextBox.Text = _instance.TitleText ?? _instance.Name;
             TitleTextAlignmentComboBox.SelectedIndex = (int)_instance.TitleTextAlignment;
+            UpdateBorderColorEnabled();
             ValidateSettings();
         }
 
@@ -32,6 +36,11 @@ namespace DeskFrame
             ValidateSettings();
         }
 
+        private void BorderColorTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            ValidateSettings();
+        }
+
         private void TitleTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
             ValidateSettings();
@@ -40,6 +49,17 @@ namespace DeskFrame
         private void TitleTextAlignmentComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             ValidateSettings();
+        }
+
+        private void BorderEnabledCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdateBorderColorEnabled();
+            ValidateSettings();
+        }
+
+        private void UpdateBorderColorEnabled()
+        {
+            BorderColorTextBox.IsEnabled = BorderEnabledCheckBox.IsChecked == true;
         }
 
         private void ValidateSettings()
@@ -64,16 +84,36 @@ namespace DeskFrame
             {
                 _isValidTitleTextColor = false;
             }
+
+            try
+            {
+                if (BorderEnabledCheckBox.IsChecked == true)
+                {
+                    var borderColor = (Color)converter.ConvertFromString(BorderColorTextBox.Text);
+                    _isValidBorderColor = true;
+                }
+                else
+                {
+                    _isValidBorderColor = true;
+                }
+            }
+            catch
+            {
+                _isValidBorderColor = false;
+            }
+
             _isValidTitleTextAlignment = TitleTextAlignmentComboBox.SelectedIndex >= 0;
-            ApplyButton.IsEnabled = _isValidTitleBarColor && _isValidTitleTextColor && _isValidTitleTextAlignment;
+            ApplyButton.IsEnabled = _isValidTitleBarColor && _isValidTitleTextColor && _isValidTitleTextAlignment && _isValidBorderColor;
         }
 
         private void ApplyButton_Click(object sender, RoutedEventArgs e)
         {
-            if (_isValidTitleBarColor && _isValidTitleTextColor && _isValidTitleTextAlignment && _isValidTitleText)
+            if (_isValidTitleBarColor && _isValidTitleTextColor && _isValidTitleTextAlignment && _isValidTitleText && _isValidBorderColor)
             {
                 _instance.TitleBarColor = TitleBarColorTextBox.Text;
                 _instance.TitleTextColor = TitleTextColorTextBox.Text;
+                _instance.BorderColor = BorderColorTextBox.Text;
+                _instance.BorderEnabled = BorderEnabledCheckBox.IsChecked == true;
                 _instance.TitleTextAlignment = (System.Windows.HorizontalAlignment)TitleTextAlignmentComboBox.SelectedIndex;
                 _instance.TitleText = TitleTextBox.Text;
                 this.DialogResult = true;


### PR DESCRIPTION
I have a black background, so it's hard to know the size of the frames (e.g. to grab the resize handle). This PR adds an option into the frame settings to allow the frame visibility and colour to be customised.

![Untitled](https://github.com/user-attachments/assets/cae09174-4678-475a-adac-121b7f50fa8c)