### PR TITLE
Add functionality to show/hide title bar icons to show/hide files and show/hide file extensions

### DIFF
--- a/DeskFrame/Core/Instance.cs
+++ b/DeskFrame/Core/Instance.cs
@@ -17,6 +17,8 @@ public class Instance : INotifyPropertyChanged
     private bool _minimized;
     private bool _showHiddenFiles;
     private bool _showFileExtension;
+    private bool _showFileExtensionIcon;
+    private bool _showHiddenFilesIcon;
     private bool _isLocked;
     private string _titleBarColor = "#0C000000";
     private string _titleTextColor = "#FFFFFF";
@@ -142,6 +144,33 @@ public class Instance : INotifyPropertyChanged
             }
         }
     }
+
+    public bool ShowFileExtensionIcon
+    {
+        get => _showFileExtensionIcon;
+        set
+        {
+            if (_showFileExtensionIcon != value)
+            {
+                _showFileExtensionIcon = value;
+                OnPropertyChanged(nameof(ShowFileExtensionIcon), value.ToString());
+            }
+        }
+    }
+
+    public bool ShowHiddenFilesIcon
+    {
+        get => _showHiddenFilesIcon;
+        set
+        {
+            if (_showHiddenFilesIcon != value)
+            {
+                _showHiddenFilesIcon = value;
+                OnPropertyChanged(nameof(ShowHiddenFilesIcon), value.ToString());
+            }
+        }
+    }
+
     public bool IsLocked
     {
         get => _isLocked;

--- a/DeskFrame/Core/InstanceController.cs
+++ b/DeskFrame/Core/InstanceController.cs
@@ -28,6 +28,8 @@ public class InstanceController
                 key.SetValue("Folder", instance.Folder!);
                 key.SetValue("ShowHiddenFiles", instance.ShowHiddenFiles!);
                 key.SetValue("ShowFileExtension", instance.ShowFileExtension!);
+                key.SetValue("ShowFileExtensionIcon", instance.ShowFileExtensionIcon!);
+                key.SetValue("ShowHiddenFilesIcon", instance.ShowHiddenFilesIcon!);
                 key.SetValue("IsLocked", instance.IsLocked!);
                 key.SetValue("TitleBarColor", instance.TitleBarColor!);
                 key.SetValue("TitleTextColor", instance.TitleTextColor!);
@@ -71,6 +73,8 @@ public class InstanceController
                 key.SetValue("Folder", instance.Folder!);
                 key.SetValue("ShowHiddenFiles", instance.ShowHiddenFiles!);
                 key.SetValue("ShowFileExtension", instance.ShowFileExtension!);
+                key.SetValue("ShowFileExtensionIcon", instance.ShowFileExtensionIcon!);
+                key.SetValue("ShowHiddenFilesIcon", instance.ShowHiddenFilesIcon!);
                 key.SetValue("IsLocked", instance.IsLocked!);
                 key.SetValue("TitleBarColor", instance.TitleBarColor!);
                 key.SetValue("TitleTextColor", instance.TitleTextColor!);
@@ -226,6 +230,14 @@ public class InstanceController
                                             case "ShowFileExtension":
                                                 temp.ShowFileExtension = bool.Parse(value.ToString()!);
                                                 Debug.WriteLine($"ShowFileExtension added\t{temp.ShowFileExtension}");
+                                                break;
+                                            case "ShowFileExtensionIcon":
+                                                temp.ShowFileExtensionIcon = bool.Parse(value.ToString()!);
+                                                Debug.WriteLine($"ShowFileExtensionIcon added\t{temp.ShowFileExtensionIcon}");
+                                                break;
+                                            case "ShowHiddenFilesIcon":
+                                                temp.ShowHiddenFilesIcon = bool.Parse(value.ToString()!);
+                                                Debug.WriteLine($"ShowHiddenFilesIcon added\t{temp.ShowHiddenFilesIcon}");
                                                 break;
                                             case "IsLocked":
                                                 temp.IsLocked = bool.Parse(value.ToString()!);

--- a/DeskFrame/DeskFrameWindow.xaml
+++ b/DeskFrame/DeskFrameWindow.xaml
@@ -76,77 +76,84 @@
     </WindowChrome.WindowChrome>
     <Border CornerRadius="5" x:Name="windowBorder" Background="#02000000" BorderThickness="{Binding Instance.BorderEnabled, Converter={StaticResource BooleanToBorderThicknessConverter}}" BorderBrush="{Binding Instance.BorderColor}">
 
-        <Grid Margin="{Binding Instance.BorderEnabled, Converter={StaticResource MarginToBorderThicknessConverter}}">
+        <Grid>
 
-            <Border MouseRightButtonDown="titleBar_MouseRightButtonDown" x:Name="titleBar" Background="#0C000000" 
-                    Height="{Binding Instance.BorderEnabled, Converter={StaticResource TitleBarBoolToHeightConverter}}"
-                    Margin="{Binding Instance.BorderEnabled, Converter={StaticResource BooleanToBorderThicknessConverter}}"
-                   
+            <Border MouseRightButtonDown="titleBar_MouseRightButtonDown" x:Name="titleBar" Background="White" Height="30"                   
                     VerticalAlignment="Top" Cursor="SizeAll" CornerRadius="5,5,0,0">
                 <Grid  Margin="{Binding Instance.BorderEnabled, Converter={StaticResource MarginToBorderThicknessConverter}}" >
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
-                        <TextBlock x:Name="title" VerticalAlignment="Center"  HorizontalAlignment="Left" Margin="10,0" Foreground="White"  FontSize="13">
-                        </TextBlock>
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
-                        <Grid Cursor="Hand" MouseLeftButtonDown="ToggleHiddenFiles_MouseLeftButtonDown" Width="30" Background="#02000000" Name="HiddenFilesIconGrid">
-                            <ui:SymbolIcon x:Name="HiddenFilesIcon" Symbol="Eye48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
-                                <ui:SymbolIcon.RenderTransform>
-                                    <ScaleTransform x:Name="HiddenFilesScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
-                                </ui:SymbolIcon.RenderTransform>
-                            </ui:SymbolIcon>
-                        </Grid>
-                        <Grid Cursor="Hand" MouseLeftButtonDown="ToggleFileExtension_MouseLeftButtonDown" Width="30" Background="#02000000" Name="FileExtensionIconGrid">
-                            <ui:SymbolIcon x:Name="FileExtensionIcon" Symbol="Document48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
-                                <ui:SymbolIcon.RenderTransform>
-                                    <ScaleTransform x:Name="FileExtensionScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
-                                </ui:SymbolIcon.RenderTransform>
-                            </ui:SymbolIcon>
-                        </Grid>
-                        <Grid Cursor="Hand" MouseLeftButtonDown="Minimize_MouseLeftButtonDown" Width="30" Background="#02000000">
-                            <ui:SymbolIcon x:Name="ChevronIcon" Symbol="ChevronDown48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
-                                <ui:SymbolIcon.RenderTransform>
-                                    <RotateTransform x:Name="ChevronRotate" Angle="0" CenterX="0.5" CenterY="0.5" />
-                                </ui:SymbolIcon.RenderTransform>
-                                <ui:SymbolIcon.RenderTransformOrigin>
-                                    <Point X="0.5" Y="0.5"/>
-                                </ui:SymbolIcon.RenderTransformOrigin>
-                            </ui:SymbolIcon>
-                        </Grid>
-                    </StackPanel>
-                    <ui:TextBox x:Name="FilterTextBox"  HorizontalAlignment="Left"  Width="0"  Height="0" TextChanged="FilterTextBox_TextChanged" />
-                    <StackPanel x:Name="Search" Visibility="Hidden" HorizontalAlignment="Left" Orientation="Horizontal">
-                        <ui:SymbolIcon Symbol="Search48" Margin="4,0,0,0" Foreground="White" VerticalAlignment="Center" FontSize="22"/>
-                        <Label HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="14" Content=":  "  FontWeight="Bold"/>
-                        <Label x:Name="searchQuery" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="16" />
-                    </StackPanel>
+                    <Grid>
+                        <StackPanel  Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
+                                <TextBlock x:Name="title" VerticalAlignment="Center"  HorizontalAlignment="Left" Margin="10,0" Foreground="White" FontSize="13">
+                                </TextBlock>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,0">
+                                <Grid Cursor="Hand" MouseLeftButtonDown="ToggleHiddenFiles_MouseLeftButtonDown" Width="30" Background="#02000000" Name="HiddenFilesIconGrid">
+                                    <ui:SymbolIcon x:Name="HiddenFilesIcon" Symbol="Eye48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                        <ui:SymbolIcon.RenderTransform>
+                                            <ScaleTransform x:Name="HiddenFilesScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
+                                        </ui:SymbolIcon.RenderTransform>
+                                    </ui:SymbolIcon>
+                                </Grid>
+                                <Grid Cursor="Hand" MouseLeftButtonDown="ToggleFileExtension_MouseLeftButtonDown" Width="30" Background="#02000000" Name="FileExtensionIconGrid">
+                                    <ui:SymbolIcon x:Name="FileExtensionIcon" Symbol="Document48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                        <ui:SymbolIcon.RenderTransform>
+                                            <ScaleTransform x:Name="FileExtensionScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
+                                        </ui:SymbolIcon.RenderTransform>
+                                    </ui:SymbolIcon>
+                                </Grid>
+                                <Grid Cursor="Hand" MouseLeftButtonDown="Minimize_MouseLeftButtonDown" Width="30" Background="#02000000">
+                                    <ui:SymbolIcon x:Name="ChevronIcon" Symbol="ChevronDown48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                        <ui:SymbolIcon.RenderTransform>
+                                            <RotateTransform x:Name="ChevronRotate" Angle="0" CenterX="0.5" CenterY="0.5" />
+                                        </ui:SymbolIcon.RenderTransform>
+                                        <ui:SymbolIcon.RenderTransformOrigin>
+                                            <Point X="0.5" Y="0.5"/>
+                                        </ui:SymbolIcon.RenderTransformOrigin>
+                                    </ui:SymbolIcon>
+                                </Grid>
+                            </StackPanel>
+                            <ui:TextBox x:Name="FilterTextBox"  HorizontalAlignment="Left"  Width="0"  Height="0" TextChanged="FilterTextBox_TextChanged" />
+                            <StackPanel x:Name="Search" Visibility="Collapsed" HorizontalAlignment="Left" Orientation="Horizontal">
+                                <ui:SymbolIcon Symbol="Search48" Margin="4,0,0,0" Foreground="White" VerticalAlignment="Center" FontSize="22"/>
+                                <Label HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="14" Content=":  "  FontWeight="Bold"/>
+                                <Label x:Name="searchQuery" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="16" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Grid>
                 </Grid>
             </Border>
 
-
-            <Grid>
-                <Grid x:Name="showFolder">
-                    <ui:DynamicScrollViewer  x:Name="scrollViewer"  IsTabStop="False" VerticalScrollBarVisibility="Auto" Margin="0,30,0,0" >
-                        <ItemsControl Margin="0,5,0,0" x:Name="FileWrapPanel" IsTabStop="False" ItemsSource="{Binding FileItems}" ItemTemplate="{StaticResource FileItemTemplate}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <WrapPanel ItemWidth="85" HorizontalAlignment="Left" VerticalAlignment="Top" ClipToBounds="True"/>
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                        </ItemsControl>
-                    </ui:DynamicScrollViewer>
+            <Border >
+                <Grid>
+                    <Grid x:Name="showFolder">
+                        <ui:DynamicScrollViewer  x:Name="scrollViewer"  IsTabStop="False" VerticalScrollBarVisibility="Auto" Margin="0,30,0,0" >
+                            <ItemsControl Padding="0,5,0,0" x:Name="FileWrapPanel" IsTabStop="False" ItemsSource="{Binding FileItems}" ItemTemplate="{StaticResource FileItemTemplate}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel ItemWidth="85" HorizontalAlignment="Left" VerticalAlignment="Top" ClipToBounds="True"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                            </ItemsControl>
+                        </ui:DynamicScrollViewer>
+                    </Grid>
+                    <Grid x:Name="addFolder" Visibility="Hidden">
+                        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" >
+                            <TextBlock Text="Drop a folder" HorizontalAlignment="Center" Foreground="White" FontSize="14" Padding="0,0,0,10"/>
+                            <ui:SymbolIcon Symbol="Add48" FontSize="88" Foreground="White" OpacityMask="#4CFFFFFF"/>
+                        </StackPanel>
+                    </Grid>
                 </Grid>
-                <Grid x:Name="addFolder" Visibility="Hidden">
-                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" >
-                        <TextBlock Text="Drop a folder" HorizontalAlignment="Center" Foreground="White" FontSize="14" Padding="0,0,0,10"/>
-                        <ui:SymbolIcon Symbol="Add48" FontSize="88" Foreground="White" OpacityMask="#4CFFFFFF"/>
-                    </StackPanel>
-                </Grid>
-            </Grid>
+            </Border>
+            <Border x:Name="WindowBorder" 
+                    CornerRadius="5"
+                    BorderThickness="{Binding Instance.BorderEnabled, Converter={StaticResource BooleanToBorderThicknessConverter}}" 
+                    BorderBrush="{Binding Instance.BorderColor}"
+             />
 
         </Grid>
     </Border>

--- a/DeskFrame/DeskFrameWindow.xaml
+++ b/DeskFrame/DeskFrameWindow.xaml
@@ -87,11 +87,12 @@
                     </Grid.ColumnDefinitions>
                     <Grid>
                         <StackPanel  Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
-                            <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
-                                <TextBlock x:Name="title" VerticalAlignment="Center"  HorizontalAlignment="Left" Margin="10,0" Foreground="White" FontSize="13">
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
+                                <TextBlock x:Name="title" VerticalAlignment="Center"  HorizontalAlignment="Left" Margin="10,0,50,0" Foreground="White" FontSize="13">
                                 </TextBlock>
                             </StackPanel>
-                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,0">
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,0,0">
                                 <Grid Cursor="Hand" MouseLeftButtonDown="ToggleHiddenFiles_MouseLeftButtonDown" Width="30" Background="#02000000" Name="HiddenFilesIconGrid">
                                     <ui:SymbolIcon x:Name="HiddenFilesIcon" Symbol="Eye48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
                                         <ui:SymbolIcon.RenderTransform>
@@ -118,11 +119,10 @@
                                 </Grid>
                             </StackPanel>
                             <ui:TextBox x:Name="FilterTextBox"  HorizontalAlignment="Left"  Width="0"  Height="0" TextChanged="FilterTextBox_TextChanged" />
-                            <StackPanel x:Name="Search" Visibility="Collapsed" HorizontalAlignment="Left" Orientation="Horizontal">
-                                <ui:SymbolIcon Symbol="Search48" Margin="4,0,0,0" Foreground="White" VerticalAlignment="Center" FontSize="22"/>
-                                <Label HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="14" Content=":  "  FontWeight="Bold"/>
-                                <Label x:Name="searchQuery" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="16" />
-                            </StackPanel>
+                        <StackPanel x:Name="Search" Visibility="Collapsed" HorizontalAlignment="Left" Orientation="Horizontal">
+                            <ui:SymbolIcon Symbol="Search48" Margin="4,0,0,0" Foreground="White" VerticalAlignment="Center" FontSize="22"/>
+                            <Label HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="14" Content=":  "  FontWeight="Bold"/>
+                            <Label x:Name="searchQuery" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="16" />
                         </StackPanel>
                     </Grid>
                 </Grid>

--- a/DeskFrame/DeskFrameWindow.xaml
+++ b/DeskFrame/DeskFrameWindow.xaml
@@ -84,20 +84,40 @@
                    
                     VerticalAlignment="Top" Cursor="SizeAll" CornerRadius="5,5,0,0">
                 <Grid  Margin="{Binding Instance.BorderEnabled, Converter={StaticResource MarginToBorderThicknessConverter}}" >
-                    <StackPanel  Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="{Binding Instance.TitleTextAlignment}" Margin="{Binding Instance.TitleTextAlignment, Converter={StaticResource TitleTextAlignmentToMarginConverter}}" VerticalAlignment="Center" >
                         <TextBlock x:Name="title" VerticalAlignment="Center"  HorizontalAlignment="Left" Margin="10,0" Foreground="White"  FontSize="13">
                         </TextBlock>
                     </StackPanel>
-                    <Grid Cursor="Hand" MouseLeftButtonDown="Minimize_MouseLeftButtonDown" Width="30" HorizontalAlignment="Right" Background="#02000000">
-                        <ui:SymbolIcon x:Name="ChevronIcon" Symbol="ChevronDown48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
-                            <ui:SymbolIcon.RenderTransform>
-                                <RotateTransform x:Name="ChevronRotate" Angle="0" CenterX="0.5" CenterY="0.5" />
-                            </ui:SymbolIcon.RenderTransform>
-                            <ui:SymbolIcon.RenderTransformOrigin>
-                                <Point X="0.5" Y="0.5"/>
-                            </ui:SymbolIcon.RenderTransformOrigin>
-                        </ui:SymbolIcon>
-                    </Grid>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,5,0">
+                        <Grid Cursor="Hand" MouseLeftButtonDown="ToggleHiddenFiles_MouseLeftButtonDown" Width="30" Background="#02000000" Name="HiddenFilesIconGrid">
+                            <ui:SymbolIcon x:Name="HiddenFilesIcon" Symbol="Eye48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                <ui:SymbolIcon.RenderTransform>
+                                    <ScaleTransform x:Name="HiddenFilesScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
+                                </ui:SymbolIcon.RenderTransform>
+                            </ui:SymbolIcon>
+                        </Grid>
+                        <Grid Cursor="Hand" MouseLeftButtonDown="ToggleFileExtension_MouseLeftButtonDown" Width="30" Background="#02000000" Name="FileExtensionIconGrid">
+                            <ui:SymbolIcon x:Name="FileExtensionIcon" Symbol="Document48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                <ui:SymbolIcon.RenderTransform>
+                                    <ScaleTransform x:Name="FileExtensionScale" ScaleX="1" ScaleY="1" CenterX="0.5" CenterY="0.5" />
+                                </ui:SymbolIcon.RenderTransform>
+                            </ui:SymbolIcon>
+                        </Grid>
+                        <Grid Cursor="Hand" MouseLeftButtonDown="Minimize_MouseLeftButtonDown" Width="30" Background="#02000000">
+                            <ui:SymbolIcon x:Name="ChevronIcon" Symbol="ChevronDown48" Foreground="{Binding ElementName=title, Path=Foreground}" Width="20" Height="20" FontSize="20">
+                                <ui:SymbolIcon.RenderTransform>
+                                    <RotateTransform x:Name="ChevronRotate" Angle="0" CenterX="0.5" CenterY="0.5" />
+                                </ui:SymbolIcon.RenderTransform>
+                                <ui:SymbolIcon.RenderTransformOrigin>
+                                    <Point X="0.5" Y="0.5"/>
+                                </ui:SymbolIcon.RenderTransformOrigin>
+                            </ui:SymbolIcon>
+                        </Grid>
+                    </StackPanel>
                     <ui:TextBox x:Name="FilterTextBox"  HorizontalAlignment="Left"  Width="0"  Height="0" TextChanged="FilterTextBox_TextChanged" />
                     <StackPanel x:Name="Search" Visibility="Hidden" HorizontalAlignment="Left" Orientation="Horizontal">
                         <ui:SymbolIcon Symbol="Search48" Margin="4,0,0,0" Foreground="White" VerticalAlignment="Center" FontSize="22"/>

--- a/DeskFrame/DeskFrameWindow.xaml.cs
+++ b/DeskFrame/DeskFrameWindow.xaml.cs
@@ -545,7 +545,7 @@ namespace DeskFrame
         {
             if (string.IsNullOrEmpty(FilterTextBox.Text))
             {
-                Search.Visibility = Visibility.Hidden;
+                Search.Visibility = Visibility.Collapsed;
                 title.Visibility = Visibility.Visible;
             }
             else

--- a/DeskFrame/DeskFrameWindow.xaml.cs
+++ b/DeskFrame/DeskFrameWindow.xaml.cs
@@ -1,43 +1,39 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
-using System.Runtime.InteropServices;
-using System.Windows.Media;
-using System.Windows.Input;
-using System.Windows.Interop;
+﻿using DeskFrame.Util;
+using Microsoft.Win32;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
-using Point = System.Drawing.Point;
+using System.Windows.Media.Imaging;
+using System.Windows.Shell;
+using Wpf.Ui.Controls;
+using Application = System.Windows.Application;
+using Brush = System.Windows.Media.Brush;
+using Brushes = System.Windows.Media.Brushes;
+using Color = System.Windows.Media.Color;
+using ColorConverter = System.Windows.Media.ColorConverter;
 using DataFormats = System.Windows.DataFormats;
-using DragEventArgs = System.Windows.DragEventArgs;
 using DataObject = System.Windows.DataObject;
 using DragDropEffects = System.Windows.DragDropEffects;
-using MouseEventArgs = System.Windows.Input.MouseEventArgs;
-using Color = System.Windows.Media.Color;
-using Application = System.Windows.Application;
-using Brushes = System.Windows.Media.Brushes;
-using Brush = System.Windows.Media.Brush;
-using DeskFrame.Util;
+using DragEventArgs = System.Windows.DragEventArgs;
 using MenuItem = Wpf.Ui.Controls.MenuItem;
-using Microsoft.Win32;
-using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
 using MessageBox = Wpf.Ui.Controls.MessageBox;
-using System.Windows.Data;
-using System.Text.RegularExpressions;
-using System.Collections;
-using Windows.Foundation.Collections;
-using System.Windows.Shell;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
-using System.Windows.Controls.Primitives;
-using Wpf.Ui.Controls;
-using ColorConverter = System.Windows.Media.ColorConverter;
+using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
+using MouseEventArgs = System.Windows.Input.MouseEventArgs;
+using Point = System.Drawing.Point;
 using TextBlock = Wpf.Ui.Controls.TextBlock;
-using System.Windows.Documents;
+
 namespace DeskFrame
 {
     public partial class DeskFrameWindow : System.Windows.Window
@@ -760,6 +756,52 @@ namespace DeskFrame
             HandleWindowMove();
         }
 
+        private void ToggleFileExtension_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            ToggleFileExtension();
+            LoadFiles(_path);
+            UpdateFileExtensionIcon();
+        }
+
+        private void ToggleHiddenFiles_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            ToggleHiddenFiles();
+            LoadFiles(_path);
+            UpdateHiddenFilesIcon();
+        }
+
+        private void UpdateFileExtensionIcon()
+        {
+            if (Instance.ShowFileExtension)
+            {
+                FileExtensionIcon.Symbol = SymbolRegular.Document48;
+                FileExtensionScale.ScaleX = 1;
+                FileExtensionScale.ScaleY = 1;
+            }
+            else
+            {
+                FileExtensionIcon.Symbol = SymbolRegular.Document48;
+                FileExtensionScale.ScaleX = 0.6;
+                FileExtensionScale.ScaleY = 0.6;
+            }
+        }
+
+        private void UpdateHiddenFilesIcon()
+        {
+            if (Instance.ShowHiddenFiles)
+            {
+                HiddenFilesIcon.Symbol = SymbolRegular.Eye48;
+                HiddenFilesScale.ScaleX = 1;
+                HiddenFilesScale.ScaleY = 1;
+            }
+            else
+            {
+                HiddenFilesIcon.Symbol = SymbolRegular.Eye48;
+                HiddenFilesScale.ScaleX = 0.6;
+                HiddenFilesScale.ScaleY = 0.6;
+            }
+        }
+
         private void AnimateWindowHeight(double targetHeight)
         {
             var animation = new DoubleAnimation
@@ -1236,6 +1278,9 @@ namespace DeskFrame
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            UpdateFileExtensionIcon();
+            UpdateHiddenFilesIcon();
+            UpdateIconVisibility();
             AnimateChevron(_isMinimized, true);
             KeepWindowBehind();
             RegistryHelper rgh = new RegistryHelper("DeskFrame");
@@ -1244,7 +1289,6 @@ namespace DeskFrame
             {
                 toBlur = (bool)rgh.ReadKeyValueRoot("blurBackground");
             }
-
 
             BackgroundType(toBlur);
         }
@@ -1700,6 +1744,18 @@ namespace DeskFrame
                        Minimize_MouseLeftButtonDown(null, null);
                    });
                 });
+            }
+        }
+
+        public void UpdateIconVisibility()
+        {
+            if (FileExtensionIcon != null)
+            {
+                FileExtensionIconGrid.Visibility = Instance.ShowFileExtensionIcon ? Visibility.Visible : Visibility.Collapsed;
+            }
+            if (HiddenFilesIcon != null)
+            {
+                HiddenFilesIconGrid.Visibility = Instance.ShowHiddenFilesIcon ? Visibility.Visible : Visibility.Collapsed;
             }
         }
     }

--- a/DeskFrame/DeskFrameWindow.xaml.cs
+++ b/DeskFrame/DeskFrameWindow.xaml.cs
@@ -774,15 +774,11 @@ namespace DeskFrame
         {
             if (Instance.ShowFileExtension)
             {
-                FileExtensionIcon.Symbol = SymbolRegular.Document48;
-                FileExtensionScale.ScaleX = 1;
-                FileExtensionScale.ScaleY = 1;
+                FileExtensionIcon.Symbol = SymbolRegular.DocumentSplitHint24;
             }
             else
             {
-                FileExtensionIcon.Symbol = SymbolRegular.Document48;
-                FileExtensionScale.ScaleX = 0.6;
-                FileExtensionScale.ScaleY = 0.6;
+                FileExtensionIcon.Symbol = SymbolRegular.DocumentSplitHintOff24;
             }
         }
 
@@ -790,15 +786,11 @@ namespace DeskFrame
         {
             if (Instance.ShowHiddenFiles)
             {
-                HiddenFilesIcon.Symbol = SymbolRegular.Eye48;
-                HiddenFilesScale.ScaleX = 1;
-                HiddenFilesScale.ScaleY = 1;
+                HiddenFilesIcon.Symbol = SymbolRegular.Eye24;
             }
             else
             {
-                HiddenFilesIcon.Symbol = SymbolRegular.Eye48;
-                HiddenFilesScale.ScaleX = 0.6;
-                HiddenFilesScale.ScaleY = 0.6;
+                HiddenFilesIcon.Symbol = SymbolRegular.EyeOff24;
             }
         }
 

--- a/DeskFrame/FrameSettingsDialog.xaml
+++ b/DeskFrame/FrameSettingsDialog.xaml
@@ -12,7 +12,7 @@
         Background="#66232323" 
         WindowStyle="None" 
         ResizeMode="NoResize"
-        Height="432" 
+        Height="492" 
         Width="490"
         MinWidth="0"
         MinHeight="0">
@@ -49,6 +49,12 @@
                     <Label Content="Background color (hex):" Height="30"/>
                 </StackPanel>
                 <ui:TextBox x:Name="ListViewBackgroundColorTextBox" PlaceholderText="#0C000000" Margin="0,0,0,20" TextChanged="TextChangedHandler"/>
+
+                <Label Content="Titlebar Icons:" Height="30"/>
+                <StackPanel Orientation="Vertical">
+                    <CheckBox x:Name="ShowFileExtensionIconCheckBox" Content="File Extensions" Margin="-11,0,10,0" Checked="ShowFileExtensionIconCheckBox_Checked" Unchecked="ShowFileExtensionIconCheckBox_Checked"/>
+                    <CheckBox x:Name="ShowHiddenFilesIconCheckBox" Content="Hidden Files" Margin="-11,0,0,0" Checked="ShowHiddenFilesIconCheckBox_Checked" Unchecked="ShowHiddenFilesIconCheckBox_Checked"/>
+                </StackPanel>
 
             </StackPanel>
             <Separator HorizontalAlignment="Center"  Grid.Column="1" Height="368"/>

--- a/DeskFrame/FrameSettingsDialog.xaml.cs
+++ b/DeskFrame/FrameSettingsDialog.xaml.cs
@@ -37,6 +37,8 @@ namespace DeskFrame
             FileFilterRegexTextBox.Text = _instance.FileFilterRegex;
             FileFilterHideRegexTextBox.Text = _instance.FileFilterHideRegex;
             TitleTextAlignmentComboBox.SelectedIndex = (int)_instance.TitleTextAlignment;
+            ShowFileExtensionIconCheckBox.IsChecked = _instance.ShowFileExtensionIcon;
+            ShowHiddenFilesIconCheckBox.IsChecked = _instance.ShowHiddenFilesIcon;
 
             UpdateBorderColorEnabled();
             ValidateSettings();
@@ -201,6 +203,18 @@ namespace DeskFrame
         private void Titlebar_CloseClicked(TitleBar sender, RoutedEventArgs args)
         {
             this.DialogResult = true;
+        }
+
+        private void ShowFileExtensionIconCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            _instance.ShowFileExtensionIcon = ShowFileExtensionIconCheckBox.IsChecked ?? false;
+            _frame.UpdateIconVisibility();
+        }
+
+        private void ShowHiddenFilesIconCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            _instance.ShowHiddenFilesIcon = ShowHiddenFilesIconCheckBox.IsChecked ?? false;
+            _frame.UpdateIconVisibility();
         }
     }
 }


### PR DESCRIPTION
I think this works better than having the options in the menu (though I've left them there).
The icons is probably incorrect, and I can't find a suitable icon for the opposite state so currently I just scale the icon smaller 🤷

![Untitled](https://github.com/user-attachments/assets/b990f3df-8eb9-46e3-ac07-bcfe21fa232e)